### PR TITLE
Add build for linux host

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -29,7 +29,8 @@ jobs:
             run: |
                  sudo apt update && \
                  sudo apt install -y git python3 && \
-                 sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential libusb-1.0-0-dev
+                 sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential libusb-1.0-0-dev && \
+                 sudo apt install -y ninja-build
                  
           - name: Check out this repository
             uses: actions/checkout@v3
@@ -70,15 +71,23 @@ jobs:
                  cd picotool/ && \
                  mkdir build && \
                  cd build && \
-                 cmake .. && \
-                 make
+                 cmake -G Ninja .. && \
+                 cmake --build .
 
           - name: Build the project
             run: |
                  export PICO_SDK_PATH=$HOME/pico-sdk && \
                  mkdir build && cd build && \
-                 cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DOVERCLOCKING=366 .. && \
-                 make
+                 cmake -G Ninja -DCMAKE_BUILD_TYPE=MinSizeRel -DOVERCLOCKING=366 .. && \
+                 cmake --build .
+
+          - name: Build for linux host
+            run: |
+                 sudo apt install -y libsdl2-dev && \
+                 export PICO_SDK_PATH=$HOME/pico-sdk && \
+                 mkdir build-linux && cd build-linux && \
+                 cmake -G Ninja -DPICO_PLATFORM=host .. && \
+                 cmake --build .
 
           - name: Create release
             uses: softprops/action-gh-release@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,12 @@ if (PICO_PLATFORM STREQUAL "host")
     link_directories(
             ${SDL2_LIB_DIR}
     )
+
+    # Enable compiler and linker garbage collect unused code/data sections
+    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -ffunction-sections -fdata-sections")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections")
+    add_link_options(-Wl,--gc-sections)
+
 else ()
     #add_compile_definitions(${PROJECT_NAME} NO_GRAPHICS)
     set(FAMILY rp2040)


### PR DESCRIPTION
Add build for linux host

Enable compiler and linker garbage collect unused code/data sectiongs.

Use ninja as build backend instead of make to maximize build speed at gh actions.
The build agent at the gh actions is unknown,
but ninja by default builds on all possible cores.